### PR TITLE
fix: fix thread reply error

### DIFF
--- a/src/bot/bot.ts
+++ b/src/bot/bot.ts
@@ -75,7 +75,7 @@ export class Bot extends GrammyBot<BotContext> {
    */
   public async announce(text: string, other?: Parameters<typeof this.api.sendMessage>[2], chat = defaultChat) {
     await this.api.sendMessage(chat?.chatId, text, {
-      direct_messages_topic_id: chat?.topicId,
+      message_thread_id: chat?.topicId,
       parse_mode: "MarkdownV2",
       ...other,
     });


### PR DESCRIPTION
To send message to threads the `announce` method should uses `message_thread_id` instead of `direct_messages_topic_id`.