### PR TITLE
fix: change whoami to use username

### DIFF
--- a/locales/en.ftl
+++ b/locales/en.ftl
@@ -59,6 +59,9 @@ cmd_whoami =
 cmd_whoami_not_found =
     I've never seen you before.
 
+cmd_whoami_no_username =
+    If you don't know, why should I?
+
 cmd_link_help =
     ✍️ `/link` Guide:
 
@@ -113,7 +116,7 @@ e_pull_request_review_requested =
     ✨ PR Review Requested\!
 
     👤 Requester: [{ $requester }]({ $requesterUrl })
-    
+
     — { $prUrl }
     Reviewers:
     { $reviewers }

--- a/src/bot/commands/link.ts
+++ b/src/bot/commands/link.ts
@@ -6,8 +6,6 @@ import { db, schema } from "@/db";
 
 import type { BotContext } from "../context";
 
-import { escapeMarkdown } from "../../lib/escape-markdown";
-
 export async function linkHandler(ctx: BotContext) {
   if (!ctx.message) return;
 


### PR DESCRIPTION
This PR changes whoami lookup from telegram id to telegram username, since the link command does not include id and it's not reliable.